### PR TITLE
Fix typo preventing use of tool by Ollama models

### DIFF
--- a/stock_analysis/tools/calculator_tools.py
+++ b/stock_analysis/tools/calculator_tools.py
@@ -3,7 +3,7 @@ from langchain.tools import tool
 
 class CalculatorTools():
 
-  @tool("Make a calcualtion")
+  @tool("Make a calculation")
   def calculate(operation):
     """Useful to perform any mathematical calculations, 
     like sum, minus, multiplication, division, etc.


### PR DESCRIPTION
While testing with Ollama it was unable to call the calculation tool.