### PR TITLE
Added sections for basic and advanced examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ crewAI is designed to facilitate the collaboration of role-playing AI agents.
 This is a collection of examples of different ways to use the crewAI framework to automate the processes.
 By [@joaomdmoura](https://x.com/joaomdmoura).
 
-
 ## Examples
+
+### Basic Examples
 - [Trip Planner](https://github.com/joaomdmoura/crewAI-examples/tree/main/trip_planner)
-- [Stock Analysis](https://github.com/joaomdmoura/crewAI-examples/tree/main/stock_analysis)
-- [Landing Page Generator](https://github.com/joaomdmoura/crewAI-examples/tree/main/landing_page_generator)
 - [Create Instagram Post](https://github.com/joaomdmoura/crewAI-examples/tree/main/instagram_post)
 - [Markdown Validator](https://github.com/joaomdmoura/crewAI-examples/tree/main/markdown_validator)
-- [Using Azure OpenAI API](https://github.com/joaomdmoura/crewAI-examples/tree/main/azure_model)
 - [Game Generator](https://github.com/joaomdmoura/crewAI-examples/tree/main/game-builder-crew)
+- [Using Azure OpenAI API](https://github.com/joaomdmoura/crewAI-examples/tree/main/azure_model)
+
+Starting your own example 
+  - [Starter Template](https://github.com/joaomdmoura/crewAI-examples/tree/main//starter_template)
+### Advanced Examples
+- [Stock Analysis](https://github.com/joaomdmoura/crewAI-examples/tree/main/stock_analysis)
+- [Landing Page Generator](https://github.com/joaomdmoura/crewAI-examples/tree/main/landing_page_generator)
 - [CrewAI + LangGraph](https://github.com/joaomdmoura/crewAI-examples/tree/main/CrewAI-LangGraph)


### PR DESCRIPTION
As mentioned in discord I've added sub-sections to the example sections to indicate how "complex" the example is.

basic examples:
- scripts with easy to understand code or templates 

advanced examples:
- complex scripts that use lots of tools or are have more complex workflows 

I did not change the directory structure since some of the Youtube videos directly link to them :/.