### PR TITLE
Fix verbose to avoid pydantic error

### DIFF
--- a/job-posting/src/job_posting/crew.py
+++ b/job-posting/src/job_posting/crew.py
@@ -92,5 +92,5 @@ class JobPostingCrew:
             agents=self.agents,  # Automatically created by the @agent decorator
             tasks=self.tasks,  # Automatically created by the @task decorator
             process=Process.sequential,
-            verbose=2,
+            verbose=True,
         )


### PR DESCRIPTION
When running the script I was getting an error:

pydantic_core._pydantic_core.ValidationError: 1 validation error for Crew
verbose
 Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value=2, input_type=int]

Updated and verified that using a boolean resolves the error.