### PR TITLE
Fix README: correct default value of verbose (True instead of False)

### DIFF
--- a/crews/starter_template/README.md
+++ b/crews/starter_template/README.md
@@ -23,7 +23,7 @@ This is the main file that you will use to run your custom crew.
 To create a Crew , you need to define Agent ,Task and following Parameters:
 1. Agent: List of agents that you want to include in the crew.
 2. Task: List of tasks that you want to include in the crew.
-3. verbose: If True, print the output of each task.(default is False).
+3. verbose: If True, print the output of each task.(default is True).
 4. debug: If True, print the debug logs.(default is False).
 
     [More Details about Crew](https://docs.crewai.com/concepts/crew).


### PR DESCRIPTION
This PR fixes the inconsistency between the documentation and the code regarding the default value of verbose in craws/starter-template project.

Before:
README stated the default was False.

Actual in code:
Default is set to True in agents.py.

✅ Changes in this PR

Updated README.md to correctly state that the default is True.

📌 Notes

If the maintainers prefer the default to be False, I can update the code instead of the README.

This PR ensures users are not misled by conflicting information.