### PR TITLE
Add the AgentSpec adapter demo

### DIFF
--- a/integrations/oracle-agentspec/.gitignore
+++ b/integrations/oracle-agentspec/.gitignore
@@ -1,0 +1,2 @@
+agent-spec/
+crewAI/

--- a/integrations/oracle-agentspec/README.md
+++ b/integrations/oracle-agentspec/README.md
@@ -1,0 +1,13 @@
+# Using AgentSpec to bring cross-framework agents into CrewAI
+
+## Introduction
+
+This is an example of how to use Oracle's [AgentSpec](https://github.com/oracle/agent-spec.git) 
+to import a LangGraph agent into CrewAI and use it inside of a Crew.
+
+## Running the code
+
+* Create a virtual environment in python
+* Install the requirements: `sh install.sh`
+* Run the demo script: `python demo.py`
+

--- a/integrations/oracle-agentspec/agentspec_langgraph_agent.json
+++ b/integrations/oracle-agentspec/agentspec_langgraph_agent.json
@@ -1,0 +1,98 @@
+{
+    "component_type": "Agent",
+    "id": "b83d62f0-04cc-4cd4-a677-0bbb8667b5d3",
+    "name": "langgraph_assistant",
+    "description": null,
+    "metadata": {},
+    "inputs": [],
+    "outputs": [],
+    "llm_config": {
+        "component_type": "VllmConfig",
+        "id": "4423c3b9-3f94-4074-a4fb-691cdb16edf8",
+        "name": "/storage/models/Llama-3.1-70B-Instruct",
+        "description": null,
+        "metadata": {},
+        "default_generation_parameters": null,
+        "url": "llama70b.wayflow.oraclecorp.com",
+        "model_id": "/storage/models/Llama-3.1-70B-Instruct"
+    },
+    "system_prompt": "Use tools to solve tasks.",
+    "tools": [
+        {
+            "component_type": "ServerTool",
+            "id": "b2db3913-98b5-42f2-bef4-3b644f278aec",
+            "name": "add",
+            "description": "Adds `a` and `b`.\n\n    Args:\n        a: First int\n        b: Second int",
+            "metadata": {},
+            "inputs": [
+                {
+                    "properties": {
+                        "a": {
+                            "type": "integer"
+                        },
+                        "b": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "a",
+                        "b"
+                    ],
+                    "type": "object"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "component_type": "ServerTool",
+            "id": "e409d992-2fca-4268-a2d8-5b98c7a47b5a",
+            "name": "multiply",
+            "description": "Multiply `a` and `b`.\n\n    Args:\n        a: First int\n        b: Second int",
+            "metadata": {},
+            "inputs": [
+                {
+                    "properties": {
+                        "a": {
+                            "type": "integer"
+                        },
+                        "b": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "a",
+                        "b"
+                    ],
+                    "type": "object"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "component_type": "ServerTool",
+            "id": "ff7f21e6-c199-4c0e-ba14-ad1bb710bb9d",
+            "name": "divide",
+            "description": "Divide `a` and `b`.\n\n    Args:\n        a: First int\n        b: Second int",
+            "metadata": {},
+            "inputs": [
+                {
+                    "properties": {
+                        "a": {
+                            "type": "integer"
+                        },
+                        "b": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "a",
+                        "b"
+                    ],
+                    "type": "object"
+                }
+            ],
+            "outputs": []
+        }
+    ],
+    "agentspec_version": "25.4.1"
+}

--- a/integrations/oracle-agentspec/demo.py
+++ b/integrations/oracle-agentspec/demo.py
@@ -1,0 +1,102 @@
+# ==============================================================================
+# Creating a LangGraph agent
+# ==============================================================================
+
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+from pydantic import SecretStr
+
+model = ChatOpenAI(
+    base_url="llama70b.wayflow.oraclecorp.com",
+    model="/storage/models/Llama-3.1-70B-Instruct",
+    api_key=SecretStr("t"),
+)
+
+def multiply(a: int, b: int) -> int:
+    """Multiply `a` and `b`.
+
+    Args:
+        a: First int
+        b: Second int
+    """
+    return a * b
+
+
+def add(a: int, b: int) -> int:
+    """Adds `a` and `b`.
+
+    Args:
+        a: First int
+        b: Second int
+    """
+    return a + b
+
+
+def divide(a: int, b: int) -> float:
+    """Divide `a` and `b`.
+
+    Args:
+        a: First int
+        b: Second int
+    """
+    return a / b
+
+
+assistant = create_react_agent(
+    name="langgraph_assistant",
+    model=model,
+    tools=[add, multiply, divide],
+    prompt="Use tools to solve tasks.",
+)
+
+print("Created the LangGraph agent")
+
+# ==============================================================================
+# Exporting the WayFlow agent to AgentSpec
+# ==============================================================================
+
+import json
+from langgraph_agentspec_adapter import AgentSpecExporter
+
+serialized_assistant = AgentSpecExporter().to_json(assistant)
+
+json.dump(json.loads(serialized_assistant), open('agentspec_langgraph_agent.json', 'w'), indent=4)
+
+print("Exported the LangGraph agent to AgentSpec")
+
+# ==============================================================================
+# Loading the AgentSpec agent in CrewAI via AgentSpecAgentAdapter
+# ==============================================================================
+
+from crewai import Crew, Task
+from crewai.agents.agent_adapters.agentspec.agentspec_adapter import AgentSpecAgentAdapter
+
+tool_registry = {"add": add, "multiply": multiply, "divide": divide}
+
+with open('agentspec_langgraph_agent.json', 'r') as f:
+    agentspec_json = f.read()
+
+crewai_assistant = AgentSpecAgentAdapter(
+    agentspec_agent_json=agentspec_json,
+    tool_registry=tool_registry
+)
+
+print("Loaded AgentSpec into CrewAI using AgentSpecAgentAdapter")
+
+# ==============================================================================
+# Running the agent inside of a Crew
+# ==============================================================================
+
+task = Task(
+    description="{user_input}",
+    expected_output="A helpful, concise reply to the user.",
+    agent=crewai_assistant,
+)
+crew = Crew(agents=[crewai_assistant], tasks=[task])
+
+while True:
+    user_input = input("USER  >>> ")
+    if user_input.lower() in ["exit", "quit"]:
+        break
+    response = crew.kickoff(inputs={"user_input": user_input})
+    print("AGENT >>>", response)

--- a/integrations/oracle-agentspec/install.sh
+++ b/integrations/oracle-agentspec/install.sh
@@ -1,0 +1,20 @@
+# Installing agentspec and its adapters from source
+git clone https://github.com/oracle/agent-spec.git
+cd agent-spec
+
+# temporary workaround:
+# using vllm models, pending support for openai models in the agentspec crewai adapter
+git reset --hard 39e779d
+
+pip install -e pyagentspec
+pip install -e adapters/crewaiagentspecadapter
+pip install -e adapters/langgraphagentspecadapter
+
+# temporary workaround:
+# installing crewai from source to pick up the agentspec adapter
+cd ..
+# git clone https://github.com/crewAIInc/crewAI.git
+git clone https://github.com/gojkoc54/crewAI.git
+cd crewAI
+git checkout feat/agentspec-adapter
+pip install -e lib/crewai


### PR DESCRIPTION
This PR adds a demo on how to use the AgentSpec adapter (https://github.com/crewAIInc/crewAI/pull/4035) to bring a LangGraph agent into CrewAI by exporting it to AgentSpec, using the adapter to import it and finally running the agent inside of a Crew.