### PR TITLE
Add README for Agoragentic Marketplace integration

### DIFF
--- a/integrations/agoragentic_marketplace/README.md
+++ b/integrations/agoragentic_marketplace/README.md
@@ -1,0 +1,48 @@
+# CrewAI + Agoragentic Marketplace
+
+Use the [Agoragentic](https://agoragentic.com) capability marketplace as a tool source for CrewAI agents. Route any task to the best provider at runtime instead of hardcoding API endpoints.
+
+## What This Integration Does
+
+Provides CrewAI `BaseTool` subclasses for the Agoragentic marketplace:
+
+| Tool | Description |
+|------|-------------|
+| `AgoragenticSearchTool` | Search 84+ marketplace capabilities |
+| `AgoragenticInvokeTool` | Invoke a specific capability by ID |
+| `AgoragenticExecuteTool` | Route any task to the best provider (recommended) |
+| `AgoragenticMemoryTool` | Persistent memory across sessions |
+| `AgoragenticSecretStoreTool` | AES-256 encrypted secret storage |
+| `AgoragenticPassportTool` | On-chain identity verification |
+
+## Quick Start
+
+```bash
+pip install crewai requests
+export AGORAGENTIC_API_KEY="amk_your_key"
+```
+
+```python
+from agoragentic_crewai import AgoragenticSearchTool, AgoragenticInvokeTool
+
+researcher = Agent(
+    role="Market Researcher",
+    tools=[
+        AgoragenticSearchTool(api_key="amk_your_key"),
+        AgoragenticInvokeTool(api_key="amk_your_key"),
+    ],
+    goal="Find and invoke the best research tools"
+)
+```
+
+No API key? Register free: `POST https://agoragentic.com/api/quickstart`
+
+## Full Source
+
+[github.com/rhein1/agoragentic-integrations/crewai](https://github.com/rhein1/agoragentic-integrations/tree/main/crewai)
+
+## Links
+
+- [Agoragentic Docs](https://agoragentic.com/SKILL.md)
+- [OpenAPI Spec](https://agoragentic.com/openapi.yaml)
+- [Marketplace](https://agoragentic.com)


### PR DESCRIPTION
Adds an integration between CrewAI and the Agoragentic agent marketplace.

**What it does:** Provides BaseTool subclasses so CrewAI agents can search, invoke, and route tasks to 84+ marketplace capabilities. The execute-first pattern lets agents describe what they need and sets a budget cap - the router handles provider selection and USDC payment on Base L2.

**Tools provided:** Search, Invoke, Execute (router), Memory, Secrets, Passport

**Full source:** https://github.com/rhein1/agoragentic-integrations/tree/main/crewai