### PR TITLE
Fix: rename Cookbook to Quickstarts and update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 Welcome to the official collection of **complete CrewAI applications**. This repository contains end-to-end implementations that showcase how to build real-world applications using CrewAI's framework for orchestrating AI agents.
 
-> **🍳 Looking for feature-specific tutorials?** Check out [CrewAI Cookbook](https://github.com/crewAIInc/crewAI-cookbook) for focused guides on specific CrewAI features and patterns.
+> **🍳 Looking for feature-specific tutorials?** Check out [CrewAI Quickstarts](https://github.com/crewAIInc/crewAI-quickstarts) for focused guides on specific CrewAI features and patterns.
 
 ## What You'll Find Here
 
@@ -136,6 +136,6 @@ This repository is maintained by the CrewAI team. Check individual examples for 
 ## 🔗 Related Resources
 
 - **[CrewAI Framework](https://github.com/crewAIInc/crewAI)** - Main CrewAI repository
-- **[CrewAI Cookbooks](https://github.com/crewAIInc/crewAI-cookbook)** - Feature-focused tutorials and guides
+- **[CrewAI Quickstarts](https://github.com/crewAIInc/crewAI-quickstarts)** - Feature-focused tutorials and guides
 - **[CrewAI Documentation](https://docs.crewai.com)** - Comprehensive documentation
 - **[CrewAI Community](https://community.crewai.com)** - Join our community discussions


### PR DESCRIPTION
### Summary

The documentation currently refers to "CrewAI Cookbook", but the linked resource returns a 404 or redirects inconsistently.

To resolve this, I updated the references to point to the active repository:

- CrewAI Quickstarts
- https://github.com/crewAIInc/crewAI-quickstarts

### Changes

- Replaced "CrewAI Cookbook" with "CrewAI Quickstarts"
- Updated links to the Quickstarts repository

> [!NOTE]
>
> If "Cookbook" is still intended as a separate resource (e.g. docs page), I'm happy to adjust the links accordingly.
> Happy to update additional occurrences across other repositories if needed.


<img width="2001" height="921" alt="image" src="https://github.com/user-attachments/assets/a599794f-0206-4017-872c-44ace493844b" />