### PR TITLE
Add KYB compliance verification crew using Strale

### DIFF
--- a/crews/kyb_compliance_crew/README.md
+++ b/crews/kyb_compliance_crew/README.md
@@ -67,6 +67,6 @@ Sources: Bolagsverket (SE), EU VIES, Dilisense AML
 
 ## How Strale tools work
 
-`crewai-strale` exposes 250+ capabilities as CrewAI tools. The agents discover and call the right tools automatically based on their task descriptions. Each result includes a quality score (SQS) and data provenance.
+`crewai-strale` wraps Strale’s capability catalog as CrewAI tools. The agents discover and call the right tools automatically based on their task descriptions. Each result includes provenance and an SQS field that the crew can query before relying on the data.
 
 Free capabilities (no API key needed): `iban-validate`, `email-validate`, `dns-lookup`, `json-repair`, `url-to-markdown`.

--- a/crews/kyb_compliance_crew/README.md
+++ b/crews/kyb_compliance_crew/README.md
@@ -1,0 +1,72 @@
+# KYB Compliance Verification Crew
+
+A CrewAI crew that performs Know Your Business (KYB) verification using [Strale](https://strale.dev) for company data lookup, VAT validation, and compliance screening.
+
+## What it does
+
+Three agents work sequentially to verify a business entity:
+
+1. **Company Data Researcher** — Looks up official registry data and validates VAT numbers
+2. **Compliance Screening Analyst** — Screens against sanctions lists, PEP databases, and adverse media
+3. **KYB Report Writer** — Synthesizes findings into a structured verification report with risk assessment
+
+## Capabilities used
+
+This crew uses [crewai-strale](https://pypi.org/project/crewai-strale/) to access:
+
+- **Company registry data** across 27 countries (Nordic, EU, US, UK, AU)
+- **VAT validation** via EU VIES
+- **Sanctions screening** against OFAC, EU, UN, UK OFSI (120+ sources)
+- **PEP screening** — Politically Exposed Persons database
+- **Adverse media** — news coverage screening across 235,000+ sources
+
+## Setup
+
+```bash
+# Install dependencies
+pip install crewai-strale
+
+# Set your API keys
+export STRALE_API_KEY=sk_live_...    # get at https://strale.dev/signup
+export OPENAI_API_KEY=sk-...         # for the LLM
+```
+
+## Run
+
+```bash
+# Default: verifies Spotify AB (Swedish company)
+python -m kyb_compliance_crew.main
+
+# Or customize in main.py:
+inputs = {
+    "company_id": "08804411",        # UK company number
+    "company_name": "Revolut Ltd",
+    "country": "UK",
+}
+```
+
+## Example output
+
+```
+KYB VERIFICATION REPORT
+============================================================
+Company: Spotify AB
+Registration: 556703-7485 (Active)
+Jurisdiction: Sweden
+VAT: SE556703748501 (Valid)
+
+Sanctions: CLEAR — no matches found
+PEP: CLEAR — no matches found
+Adverse Media: LOW RISK — 0 financial crime hits
+
+Risk Assessment: LOW
+Recommendation: APPROVE
+
+Sources: Bolagsverket (SE), EU VIES, Dilisense AML
+```
+
+## How Strale tools work
+
+`crewai-strale` exposes 250+ capabilities as CrewAI tools. The agents discover and call the right tools automatically based on their task descriptions. Each result includes a quality score (SQS) and data provenance.
+
+Free capabilities (no API key needed): `iban-validate`, `email-validate`, `dns-lookup`, `json-repair`, `url-to-markdown`.

--- a/crews/kyb_compliance_crew/pyproject.toml
+++ b/crews/kyb_compliance_crew/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "kyb_compliance_crew"
+version = "0.1.0"
+description = "KYB (Know Your Business) compliance verification crew using Strale for company data, VAT validation, and sanctions screening"
+authors = [
+    { name = "Strale", email = "hello@strale.io" },
+]
+requires-python = ">=3.10,<=3.13"
+dependencies = [
+    "crewai[tools]>=0.152.0",
+    "crewai-strale>=0.1.4",
+]
+
+[project.scripts]
+kyb_compliance_crew = "kyb_compliance_crew.main:run"
+run_crew = "kyb_compliance_crew.main:run"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/crews/kyb_compliance_crew/src/kyb_compliance_crew/config/agents.yaml
+++ b/crews/kyb_compliance_crew/src/kyb_compliance_crew/config/agents.yaml
@@ -1,0 +1,32 @@
+company_researcher:
+  role: Company Data Researcher
+  goal: >
+    Look up official company registry data for {company_id} in {country}
+    and validate the company's VAT registration status.
+  backstory: >
+    You are an expert at verifying business entities using official government
+    registries. You use Strale tools to query company registries across 27
+    countries and validate EU VAT numbers via VIES. You always report the
+    company name, registration status, and VAT validity.
+
+compliance_screener:
+  role: Compliance Screening Analyst
+  goal: >
+    Screen {company_name} against international sanctions lists, PEP databases,
+    and adverse media sources to identify compliance risks.
+  backstory: >
+    You are an AML/KYC compliance analyst. You use Strale tools to check
+    sanctions lists (OFAC, EU, UN, UK OFSI), screen for Politically Exposed
+    Persons, and scan for adverse media coverage. You report findings clearly
+    with risk levels and source details.
+
+report_writer:
+  role: KYB Report Writer
+  goal: >
+    Synthesize the company research and compliance screening results into a
+    clear, actionable KYB verification report for {company_name}.
+  backstory: >
+    You write concise compliance reports for business onboarding decisions.
+    You combine company data, VAT validation results, and screening outcomes
+    into a structured report with a clear recommendation: approve, review, or
+    reject. You always cite the data sources.

--- a/crews/kyb_compliance_crew/src/kyb_compliance_crew/config/tasks.yaml
+++ b/crews/kyb_compliance_crew/src/kyb_compliance_crew/config/tasks.yaml
@@ -1,0 +1,46 @@
+company_lookup:
+  description: >
+    Look up company {company_id} in {country} using the appropriate Strale
+    company data capability. Also validate the company's VAT number if one
+    is available. Report: company name, registration status, address,
+    and VAT validity.
+  expected_output: >
+    A structured summary with: company name, registration number, status
+    (active/inactive), registered address, and VAT validation result
+    (valid/invalid/not checked).
+  agent: company_researcher
+
+compliance_screening:
+  description: >
+    Screen the company identified in the previous step against:
+    1. International sanctions lists (OFAC, EU, UN, UK)
+    2. PEP (Politically Exposed Persons) databases
+    3. Adverse media sources (news coverage of fraud, regulatory action, etc.)
+    Use Strale's sanctions-check, pep-check, and adverse-media-check tools.
+    Report each screening result with risk level and match details.
+  expected_output: >
+    Three screening results: sanctions (clear/flagged with sources),
+    PEP (clear/flagged with positions), and adverse media (risk level
+    with category breakdown). Include match counts and source details.
+  agent: compliance_screener
+  context:
+    - company_lookup
+
+kyb_report:
+  description: >
+    Write a KYB verification report combining the company data and
+    compliance screening results. Structure the report with:
+    1. Company overview (name, status, jurisdiction)
+    2. VAT validation result
+    3. Sanctions screening result
+    4. PEP screening result
+    5. Adverse media result
+    6. Overall risk assessment (Low / Medium / High)
+    7. Recommendation (Approve / Review / Reject)
+  expected_output: >
+    A formatted KYB verification report with all sections above,
+    ending with a clear recommendation and the data sources used.
+  agent: report_writer
+  context:
+    - company_lookup
+    - compliance_screening

--- a/crews/kyb_compliance_crew/src/kyb_compliance_crew/crew.py
+++ b/crews/kyb_compliance_crew/src/kyb_compliance_crew/crew.py
@@ -1,0 +1,78 @@
+"""KYB Compliance Verification Crew using Strale for company data and screening."""
+
+import os
+from crewai import Agent, Crew, Process, Task
+from crewai.project import CrewBase, agent, crew, task
+from crewai_strale import StraleToolkit
+
+
+@CrewBase
+class KybComplianceCrew:
+    """KYB (Know Your Business) compliance verification crew.
+
+    Uses Strale tools to:
+    - Look up company registry data across 27 countries
+    - Validate EU VAT numbers via VIES
+    - Screen against sanctions lists (OFAC, EU, UN, UK)
+    - Check PEP (Politically Exposed Persons) databases
+    - Scan adverse media coverage
+
+    Produces a structured KYB verification report with a risk assessment.
+
+    Requirements:
+        pip install crewai-strale
+        export STRALE_API_KEY=sk_live_...  # get at https://strale.dev/signup
+    """
+
+    agents_config = "config/agents.yaml"
+    tasks_config = "config/tasks.yaml"
+
+    def __init__(self):
+        self.strale_toolkit = StraleToolkit(
+            api_key=os.environ.get("STRALE_API_KEY", ""),
+        )
+        self.strale_tools = self.strale_toolkit.get_tools()
+
+    @agent
+    def company_researcher(self) -> Agent:
+        return Agent(
+            config=self.agents_config["company_researcher"],
+            tools=self.strale_tools,
+            verbose=True,
+        )
+
+    @agent
+    def compliance_screener(self) -> Agent:
+        return Agent(
+            config=self.agents_config["compliance_screener"],
+            tools=self.strale_tools,
+            verbose=True,
+        )
+
+    @agent
+    def report_writer(self) -> Agent:
+        return Agent(
+            config=self.agents_config["report_writer"],
+            verbose=True,
+        )
+
+    @task
+    def company_lookup(self) -> Task:
+        return Task(config=self.tasks_config["company_lookup"])
+
+    @task
+    def compliance_screening(self) -> Task:
+        return Task(config=self.tasks_config["compliance_screening"])
+
+    @task
+    def kyb_report(self) -> Task:
+        return Task(config=self.tasks_config["kyb_report"])
+
+    @crew
+    def crew(self) -> Crew:
+        return Crew(
+            agents=self.agents,
+            tasks=self.tasks,
+            process=Process.sequential,
+            verbose=True,
+        )

--- a/crews/kyb_compliance_crew/src/kyb_compliance_crew/main.py
+++ b/crews/kyb_compliance_crew/src/kyb_compliance_crew/main.py
@@ -1,0 +1,17 @@
+"""Run the KYB Compliance Verification Crew."""
+
+from kyb_compliance_crew.crew import KybComplianceCrew
+
+
+def run():
+    """Run a KYB check on a Swedish company (Spotify AB)."""
+    inputs = {
+        "company_id": "556703-7485",
+        "company_name": "Spotify AB",
+        "country": "SE",
+    }
+    result = KybComplianceCrew().crew().kickoff(inputs=inputs)
+    print("\n" + "=" * 60)
+    print("KYB VERIFICATION REPORT")
+    print("=" * 60)
+    print(result)


### PR DESCRIPTION
Adds a KYB (Know Your Business) compliance verification crew that uses
[crewai-strale](https://pypi.org/project/crewai-strale/) for company
data lookup, VAT validation, and AML screening.

## What it does

Three agents work sequentially:
1. **Company Data Researcher** — queries official registries (27 countries) + validates VAT via VIES
2. **Compliance Screening Analyst** — screens sanctions (OFAC/EU/UN/UK), PEP databases, adverse media
3. **KYB Report Writer** — synthesizes into a structured report with risk assessment

## Why this is useful

KYB/AML verification is a common requirement for agent pipelines in fintech,
compliance, and B2B onboarding. No existing crew in this repo covers this
use case. The Strale integration provides 250+ quality-scored data capabilities
via a single `crewai-strale` package.

## Structure

```
crews/kyb_compliance_crew/
├── README.md
├── pyproject.toml
└── src/kyb_compliance_crew/
    ├── config/agents.yaml
    ├── config/tasks.yaml
    ├── crew.py
    └── main.py
```

Follows the standard CrewBase pattern with YAML configs.

## Dependencies

- `crewai-strale` (PyPI, MIT license, v0.1.4)
- Requires `STRALE_API_KEY` env var (free trial at strale.dev/signup)