### PR TITLE
Add OSOP interop — portable workflow format for CrewAI crews

### DIFF
--- a/osop_interop/README.md
+++ b/osop_interop/README.md
@@ -1,0 +1,107 @@
+# CrewAI ↔ OSOP Interop
+
+[OSOP](https://osop.ai) (Open Standard Operating Procedures) is a YAML-based workflow standard. This example shows how CrewAI workflows can be represented in OSOP format for portability across tools.
+
+## Why?
+
+- **Portability**: Define your crew once, run it anywhere (n8n, Airflow, Argo, LangGraph)
+- **Visualization**: Render crew workflows as Mermaid diagrams or interactive editors
+- **Analysis**: Risk assessment, optimization suggestions, execution reports
+
+## Example
+
+A CrewAI research crew defined in OSOP format:
+
+```yaml
+osop_version: "1.0"
+id: "crewai-research-pipeline"
+name: "Research Pipeline Crew"
+description: "Three-agent crew that researches a topic, analyzes findings, and writes a report."
+version: "1.0.0"
+tags: [crewai, multi-agent, research, llm]
+
+nodes:
+  - id: "user_topic"
+    type: "human"
+    name: "Provide Research Topic"
+    description: "User supplies a topic and desired depth (overview / deep-dive)."
+
+  - id: "researcher"
+    type: "agent"
+    subtype: "llm"
+    name: "Researcher Agent"
+    description: "Searches the web, reads papers, and collects raw source material."
+    config:
+      role: "Senior Research Analyst"
+      tools: [web_search, arxiv_search, url_reader]
+      max_iterations: 5
+
+  - id: "analyst"
+    type: "agent"
+    subtype: "llm"
+    name: "Analyst Agent"
+    description: "Synthesizes raw sources into structured insights and key findings."
+    config:
+      role: "Data Analyst"
+      tools: [text_summarizer]
+      max_iterations: 3
+
+  - id: "writer"
+    type: "agent"
+    subtype: "llm"
+    name: "Writer Agent"
+    description: "Produces a polished markdown report with citations."
+    config:
+      role: "Technical Writer"
+      tools: [markdown_formatter]
+      max_iterations: 3
+
+  - id: "human_review"
+    type: "human"
+    subtype: "review"
+    name: "Review Report"
+    description: "User reviews the final report and requests revisions if needed."
+
+edges:
+  - from: "user_topic"
+    to: "researcher"
+    mode: "sequential"
+  - from: "researcher"
+    to: "analyst"
+    mode: "sequential"
+  - from: "analyst"
+    to: "writer"
+    mode: "sequential"
+  - from: "writer"
+    to: "human_review"
+    mode: "sequential"
+  - from: "human_review"
+    to: "writer"
+    mode: "conditional"
+    when: "revision_requested"
+    label: "Revisions needed"
+```
+
+## Convert Between Formats
+
+```bash
+# Install
+pip install osop-interop
+
+# CrewAI → OSOP
+from osop_interop.importers.crewai import CrewAIImporter
+importer = CrewAIImporter()
+osop_yaml = importer.convert(open("agents.yaml").read(), tasks_yaml=open("tasks.yaml").read())
+
+# OSOP → CrewAI
+from osop_interop.exporters.crewai import CrewAIExporter
+exporter = CrewAIExporter()
+result = exporter.convert(osop_yaml)
+# result = {"agents.yaml": "...", "tasks.yaml": "..."}
+```
+
+## Links
+- [OSOP Spec](https://github.com/Archie0125/osop-spec)
+- [OSOP Interop](https://github.com/Archie0125/osop-interop) — Format converters
+- [OSOP MCP Server](https://github.com/Archie0125/osop-mcp) — 12 MCP tools
+- [Visual Editor](https://osop-editor.vercel.app)

--- a/osop_interop/crewai-research-pipeline.osop.yaml
+++ b/osop_interop/crewai-research-pipeline.osop.yaml
@@ -1,0 +1,76 @@
+# CrewAI Research Pipeline — OSOP Portable Workflow
+#
+# A three-agent research crew: Researcher gathers sources, Analyst extracts
+# insights, Writer produces a polished report. Demonstrates how CrewAI crews
+# map 1:1 to OSOP nodes, making the workflow portable across any runtime.
+#
+# Run with CrewAI:  crewai run research_crew.py
+# Validate with OSOP: osop validate crewai-research-pipeline.osop.yaml
+
+osop_version: "1.0"
+id: "crewai-research-pipeline"
+name: "Research Pipeline Crew"
+description: "Three-agent crew that researches a topic, analyzes findings, and writes a report."
+version: "1.0.0"
+tags: [crewai, multi-agent, research, llm]
+
+nodes:
+  - id: "user_topic"
+    type: "human"
+    name: "Provide Research Topic"
+    description: "User supplies a topic and desired depth (overview / deep-dive)."
+
+  - id: "researcher"
+    type: "agent"
+    subtype: "llm"
+    name: "Researcher Agent"
+    description: "Searches the web, reads papers, and collects raw source material."
+    config:
+      role: "Senior Research Analyst"
+      tools: [web_search, arxiv_search, url_reader]
+      max_iterations: 5
+
+  - id: "analyst"
+    type: "agent"
+    subtype: "llm"
+    name: "Analyst Agent"
+    description: "Synthesizes raw sources into structured insights and key findings."
+    config:
+      role: "Data Analyst"
+      tools: [text_summarizer]
+      max_iterations: 3
+
+  - id: "writer"
+    type: "agent"
+    subtype: "llm"
+    name: "Writer Agent"
+    description: "Produces a polished markdown report with citations."
+    config:
+      role: "Technical Writer"
+      tools: [markdown_formatter]
+      max_iterations: 3
+
+  - id: "human_review"
+    type: "human"
+    subtype: "review"
+    name: "Review Report"
+    description: "User reviews the final report and requests revisions if needed."
+
+edges:
+  - from: "user_topic"
+    to: "researcher"
+    mode: "sequential"
+  - from: "researcher"
+    to: "analyst"
+    mode: "sequential"
+  - from: "analyst"
+    to: "writer"
+    mode: "sequential"
+  - from: "writer"
+    to: "human_review"
+    mode: "sequential"
+  - from: "human_review"
+    to: "writer"
+    mode: "conditional"
+    when: "revision_requested"
+    label: "Revisions needed"


### PR DESCRIPTION
## Summary

- Adds an `osop_interop/` directory with an example showing how CrewAI crews can be defined in [OSOP](https://osop.ai) (Open Standard Operating Procedures) YAML format
- Includes a three-agent research pipeline (Researcher → Analyst → Writer) as a working OSOP workflow definition
- Demonstrates bidirectional conversion between CrewAI and OSOP formats

## What is OSOP?

OSOP is a portable YAML-based workflow standard — think "OpenAPI for workflows." It lets you define agent workflows once and run them across different runtimes (CrewAI, LangGraph, n8n, Airflow, Argo). Each CrewAI agent maps 1:1 to an OSOP node, preserving role, tools, and task flow.

## Why this is useful for CrewAI users

- **Portability**: Export CrewAI crews to other platforms without rewriting
- **Visualization**: Render crew workflows as Mermaid diagrams or in the [OSOP visual editor](https://osop-editor.vercel.app)
- **Analysis**: Get risk assessment, optimization suggestions, and execution reports for crew definitions

## Changes

Purely additive — two new files in a new `osop_interop/` directory. No changes to existing code.

| File | Description |
|------|-------------|
| `osop_interop/README.md` | Usage guide with inline example and conversion snippets |
| `osop_interop/crewai-research-pipeline.osop.yaml` | Research crew defined in OSOP format |

## Test plan

- [x] OSOP YAML validates against the [OSOP spec](https://github.com/Archie0125/osop-spec)
- [x] README renders correctly on GitHub
- [x] No existing files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)