### PR TITLE
Add Decision Anchor MCP integration example

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -22,6 +22,12 @@ Integration with NVIDIA's AI model ecosystem:
 - Performance optimization examples
 - Multiple example implementations (intro, marketing strategy)
 
+### 4. Decision Anchor MCP
+Integration with Decision Anchor via MCP for external accountability proof:
+- Connects to DA's remote MCP server using `MCPServerAdapter`
+- Records decision boundaries for payments, delegation, and disputes
+- No DA API key needed — agents register via MCP tools
+
 ## Integration Patterns
 
 These examples demonstrate:

--- a/integrations/decision_anchor_mcp/README.md
+++ b/integrations/decision_anchor_mcp/README.md
@@ -1,0 +1,32 @@
+# Decision Anchor MCP Integration
+
+Connect CrewAI agents to [Decision Anchor](https://github.com/zse4321/decision-anchor-sdk)'s remote MCP server using `MCPServerAdapter`.
+
+Decision Anchor provides external accountability proof for agent payments, delegation, and disputes via MCP. It does not monitor, judge, or intervene.
+
+## What this example does
+
+1. Connects to DA's MCP server (`https://mcp.decision-anchor.com/mcp`) via `MCPServerAdapter`
+2. Registers a new agent (one-time, no DA API key required)
+3. Creates a Decision Declaration (DD) with accountability scope for a delegated task
+4. Reports the DD ID and anchored timestamp
+
+## Setup
+
+```bash
+pip install crewai crewai-tools[mcp]
+```
+
+## Usage
+
+```bash
+export OPENAI_API_KEY=your_key
+python main.py
+```
+
+## Notes
+
+- No DA API key needed — agents register via MCP tools and receive Trial 500 DAC / 30 days
+- Running this creates a real agent registration and decision record on DA
+- The MCP server uses streamable HTTP transport
+- Full agent guide: [AGENTS.md](https://github.com/zse4321/decision-anchor-sdk/blob/main/AGENTS.md)

--- a/integrations/decision_anchor_mcp/main.py
+++ b/integrations/decision_anchor_mcp/main.py
@@ -1,0 +1,78 @@
+"""CrewAI agent with Decision Anchor MCP integration.
+
+Connects CrewAI agents to Decision Anchor's remote MCP server
+using MCPServerAdapter for external accountability proof.
+
+Use case: a crew handling delegated tasks records each handoff
+boundary via DA, so that responsibility disputes between agents
+have externally-anchored proof.
+
+Requirements:
+    pip install crewai crewai-tools[mcp]
+
+Usage:
+    export OPENAI_API_KEY=your_key
+    python main.py
+"""
+
+from crewai import Agent, Crew, Process, Task
+
+from crewai_tools import MCPServerAdapter
+
+# Decision Anchor's remote MCP server — no API key needed
+da_server_params = {
+    "url": "https://mcp.decision-anchor.com/mcp",
+    "transport": "streamable_http",
+}
+
+
+def main():
+    with MCPServerAdapter(da_server_params) as da_tools:
+        accountability_agent = Agent(
+            role="Accountability Recorder",
+            goal=(
+                "Record decision boundaries for actions "
+                "that involve external effects"
+            ),
+            backstory=(
+                "You ensure that every payment, delegation, or "
+                "external action has its accountability scope "
+                "recorded externally via Decision Anchor. "
+                "This protects the team when disputes arise later."
+            ),
+            tools=da_tools,
+            verbose=True,
+        )
+
+        record_task = Task(
+            description=(
+                "1. Register as a new agent on Decision Anchor "
+                "with name 'crewai-demo-agent'. "
+                "2. Create a Decision Declaration (DD) with "
+                "action_type 'execute' and summary "
+                "'Delegated data processing task to specialist agent'. "
+                "Use retention short, integrity basic, "
+                "disclosure internal, responsibility minimal. "
+                "3. Report the DD ID and anchored timestamp."
+            ),
+            expected_output=(
+                "DD ID and timestamp confirming the decision "
+                "was externally anchored."
+            ),
+            agent=accountability_agent,
+        )
+
+        crew = Crew(
+            agents=[accountability_agent],
+            tasks=[record_task],
+            process=Process.sequential,
+            verbose=True,
+        )
+
+        result = crew.kickoff()
+        print("\n=== Result ===")
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/decision_anchor_mcp/main.py
+++ b/integrations/decision_anchor_mcp/main.py
@@ -44,15 +44,27 @@ def main():
             verbose=True,
         )
 
+        # Decision Anchor is content-blind: the core records the *shape*
+        # of a decision (type, action, scope — all enums), never its
+        # content, intent, or rationale. Do NOT send free-text summaries.
+        # What a summary would have said is expressed instead through the
+        # structured template (content_inclusion_flag=1) — closed enums.
         record_task = Task(
             description=(
-                "1. Register as a new agent on Decision Anchor "
-                "with name 'crewai-demo-agent'. "
-                "2. Create a Decision Declaration (DD) with "
-                "action_type 'execute' and summary "
-                "'Delegated data processing task to specialist agent'. "
-                "Use retention short, integrity basic, "
+                "1. Register as a new agent on Decision Anchor. "
+                "2. Create a Decision Declaration (DD) anchoring the "
+                "handoff of a data-processing task to a specialist "
+                "agent. Use decision_type 'external_interaction', "
+                "decision_action_type 'execute', origin_context_type "
+                "'internal'. Use retention short, integrity basic, "
                 "disclosure internal, responsibility minimal. "
+                "Do NOT include any free-text summary or description "
+                "of the task — Decision Anchor is content-blind and "
+                "stores only the decision's formal shape. To record "
+                "what kind of decision this is, set "
+                "content_inclusion_flag 1 with template: "
+                "decision_class 'delegation', target_class 'subagent', "
+                "decision_trigger 'delegated', human_involvement 'none'. "
                 "3. Report the DD ID and anchored timestamp."
             ),
             expected_output=(

--- a/integrations/decision_anchor_mcp/requirements.txt
+++ b/integrations/decision_anchor_mcp/requirements.txt
@@ -1,0 +1,2 @@
+crewai
+crewai-tools[mcp]


### PR DESCRIPTION
## Summary

- Add an integration example showing how to use `MCPServerAdapter` with [Decision Anchor](https://github.com/zse4321/decision-anchor-sdk)'s remote MCP server
- Decision Anchor provides external accountability proof for agent payments, delegation, and disputes via MCP
- The example creates a CrewAI agent that registers on DA, creates a Decision Declaration (DD), and reports the anchored timestamp
- No API key required for DA — agents register via MCP tools and receive Trial 500 DAC / 30 days

## Files

- `integrations/decision_anchor_mcp/main.py` — main example using `MCPServerAdapter` with streamable HTTP transport
- `integrations/decision_anchor_mcp/README.md` — setup and usage instructions
- `integrations/decision_anchor_mcp/requirements.txt` — dependencies
- `integrations/README.md` — updated index with DA entry

## Test plan

- [x] Python syntax validated (`ast.parse`)
- [x] `ruff check` passes
- [ ] Manual run with `OPENAI_API_KEY` set: `python main.py`